### PR TITLE
Filter input events of type insertCompositionText for Safari

### DIFF
--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -29,6 +29,8 @@
 
   _eventNormalize = (listener) ->
     return (e = window.event) ->
+      if e.inputType == 'insertCompositionText' and !e.isComposing
+        return
       e.target = e.target or e.srcElement
       e.which = e.which or e.keyCode
       unless e.preventDefault?


### PR DESCRIPTION
Fixes #38

## Changes

- Keeping in mind W3C's [UI keyboard event table](https://user-images.githubusercontent.com/6437556/42597589-3d6d7a08-8527-11e8-8870-60875033c334.png) these changes filters out `input` events of type `insertCompositionText` on Safari.

### Why introduce these changes?

- Improve User Experience (UX) for Safari users with input sources which utilizes IME input (e.g. Hirgana)
- Normalize inputTypes for `input` events for Safari.

### How is this achieved?

- Filter out `input` events with inputType `insertCompositionText` on `_eventNormalize()`

- ⚠️ For Safari, these changes will not format full-width input characters on the fly.  Instead, the target element's input value will only be formatted on the `compositionEnd` event type. This introduces a smaller and less significant compromise on the UX, but ultimately solves the more important issue with inconsistent values between IME and the input value.

![Safari IME demo](https://cl.ly/253m0p251b0j/Screen%20Recording%202018-07-16%20at%2001.14%20PM.gif)

### Additional Information

- Safari handles [Input Method Editors](https://en.wikipedia.org/wiki/Input_method) differently from other browsers. When surfacing `input` UI keyboard events, the `data` attribute holds different values from other non full-width input sources. Moreover, `data` is read-only. 

- While Mac OS allows users to disable IME editor through the `Live Conversion` option in keyboard preferences, `input` events of type `insertCompositionText` events are still raised and captured by the browser. 

![Live Conversion](https://cl.ly/2j3n2w3E1D0K/[421c24d91905e062dac9ebd45986c4fb]_Image%202018-07-16%20at%201.20.36%20PM.png)
