### PR TITLE
Extract KeyCodes into a variable, filter right and left arrow keys on…

### DIFF
--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -54,6 +54,16 @@
 
   payform = {}
 
+  # Key Codes
+  
+  keyCodes = {
+    UNKNOWN : 0,
+    BACKSPACE : 8,
+    PAGE_UP : 33,
+    ARROW_LEFT : 37, 
+    ARROW_RIGHT : 39,
+  }
+
   # Utils
 
   defaultFormat = /(\d{1,4})/g
@@ -253,7 +263,7 @@
     value = e.target.value
 
     # Return unless backspacing
-    return unless e.which is 8
+    return unless e.which is keyCodes.BACKSPACE
 
     # Return if focus isn't at the end of the text
     cursor = _getCaretPos(e.target)
@@ -312,7 +322,7 @@
     value = e.target.value
 
     # Return unless backspacing
-    return unless e.which is 8
+    return unless e.which is keyCodes.BACKSPACE
 
     # Return if focus isn't at the end of the text
     cursor = _getCaretPos(e.target)
@@ -339,10 +349,10 @@
     return if e.metaKey or e.ctrlKey
 
     # If keycode is a special char (WebKit)
-    return if e.which is 0
+    return if [keyCodes.UNKNOWN, keyCodes.ARROW_LEFT, keyCodes.ARROW_RIGHT].indexOf(e.which) > -1
 
     # If char is a special char (Firefox)
-    return if e.which < 33
+    return if e.which < keyCodes.PAGE_UP
 
     input = String.fromCharCode(e.which)
 


### PR DESCRIPTION
### Changes

- Allow right and left arrow key to be used while navigating inside all input types (e.g. cvc, expiry, card number and numeric)

### Why introduce these changes?

- Firefox (<i>with vendored payform</i>) currently does not allow users to perform arrow key navigation because `keypress` keyboard events are surfaced in the event handler that restricts all non-numeric keys (with some exceptions). `keypress` events are not raised in Chrome, Safari and Firefox

### How is this achieved?

- In the `restrictNumeric` keyPress event handler, we can filter out right and left arrow keys key codes (i.e. 37 and 39) 

- Extract key codes used in all comparison operators into a global variable called `keyCodes` and use it instead of using number types and in-line comments. While it may not be the most performant, it keeps in mind legacy browser support (i.e. IE < 8)